### PR TITLE
feat:회원, 게시글 기능 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 # production
 /build
 ecosystem.config.js
-
+deploy
 # misc
 .DS_Store
 *.pem

--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   compiler: {
     styledComponents: true,
-    removeConsole: {
-      exclude: ['error'],
-
-    }
+    removeConsole: process.env.NODE_ENV=='production'&&{exclude: ['error']},
     
   },
 }

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Link from 'next/link';
+import { Post } from './board/PartBoard';
 
 const InnerBox = styled.div`
   display: flex;
@@ -77,7 +78,7 @@ const Th = styled.th` // 게시글의 윗 머리 부분
   }
 `;
 
-function Board ({data}:any) {
+function Board ({data}:{data:Post[]}) {
     return (  
       <InnerBox>                 
       <Div>

--- a/src/components/auth/FindUser.tsx
+++ b/src/components/auth/FindUser.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { ErrorText, Field, LoginCard, LoginContainer, StyledLabel } from './Login';
+import styled from 'styled-components';
+import { buttonCss as buttonCSS } from './SignUp';
+
+
+const onSubmit =async (e: React.FormEvent<HTMLFormElement>)=>{
+  e.preventDefault();
+  const form = new FormData(e.target as HTMLFormElement)
+  const data={
+    userid:form.get('userId')
+  }
+    console.log(data)
+  const JSONdata = JSON.stringify(data);
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSONdata,
+  };
+  console.log(data)
+  const apiURL=`/api/${process.env.NEXT_PUBLIC_VAPI}/auth`
+
+  const response = await fetch(apiURL, options);
+  if(response.ok){
+    try {
+      switch(response.status){
+        case 201:
+          break;
+        case 200:
+          const result = await response.json();
+          break;
+        }
+    } catch (error) {
+      console.log(error)
+    }
+    
+    }else{
+    }
+  }
+
+
+function FindUser({findType}:{findType:'id'|'pw'}) {
+
+    return (
+        <LoginContainer>
+            <LoginCard>
+                <form onSubmit={onSubmit}>
+                    <StyledLabel>{findType=='id'?'아이디 찾기':findType==='pw'&&'임시 비밀번호 찾기'}</StyledLabel>
+                    {findType=='id'?<div>준비 중 입니다</div>:findType==='pw'&&<><Field type='text' placeholder='비밀번호를 찾을 아이디' name='userId' /><FindButton type='submit'>비밀번호 찾기</FindButton></>}
+                </form>
+                
+            </LoginCard>
+        </LoginContainer>
+    );
+}
+
+const FindButton=styled.button`
+  ${buttonCSS}
+`;
+
+export default FindUser;

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -3,8 +3,9 @@ import {useCallback, useState} from "react";
 import styled from "styled-components";
 import { useForm, SubmitHandler  } from "react-hook-form";
 import { useRouter } from 'next/router';
+import { useQueryClient } from '@tanstack/react-query';
 
-const Container = styled.div`
+export const LoginContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -13,7 +14,7 @@ const Container = styled.div`
   background-color: #F6FEFF;
 `;
 
-const Card = styled.div`
+export const LoginCard = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -33,7 +34,7 @@ const FieldWapper=styled.div`
   width:530px;
 `;
 
-const Field = styled.input`
+export const Field = styled.input`
   width: 100%;
   padding: 12px;
   margin-top:8px;
@@ -43,12 +44,12 @@ const Field = styled.input`
   box-sizing:border-box;
 `;
 
-const StyledLabel=styled.label`
+export const StyledLabel=styled.label`
   font-weight:600;
   font-size:16;
 `;
 
-const LoginButton = styled.button`
+export const LoginButton = styled.button`
   background-color: #000000;
   color: #fff;
   padding: 12px;
@@ -79,13 +80,14 @@ const BottomLinkWrapper=styled.div`
   border:1px;
 `;
 
-const ErrorText= styled.span`
+export const ErrorText= styled.span`
   display:inline-block;
   color:chocolate;
   font-size:14px;
   text-decoration:none;
   height:8px;
   width:100%;
+  word-wrap:keep-all;
 `;
 interface LoginProps {
   userId:string;
@@ -96,6 +98,7 @@ function Login() {
     const router= useRouter()
     const [errorText, setErrorText]=useState('');
     const { register, formState:{errors,isSubmitting}, handleSubmit } = useForm<LoginProps>({mode:'onChange'});
+    const queryClient=useQueryClient()
     const onSubmit: SubmitHandler<LoginProps> =useCallback(async (e)=>{
       const data={
         username:e.userId,
@@ -116,10 +119,12 @@ function Login() {
         try {
           switch(response.status){
             case 201:
+              queryClient.invalidateQueries(['userInfo'])
               router.push(await response.text() )
               break;
             case 200:
               const result = await response.text();
+              break;
             }
         } catch (error) {
           console.log(error)
@@ -130,9 +135,9 @@ function Login() {
         }
     },[]) 
   return (
-    <Container>
+    <LoginContainer>
         <Title>다과회</Title>
-      <Card>
+      <LoginCard>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FieldWapper>
             <StyledLabel htmlFor='userId'>아이디</StyledLabel>
@@ -153,13 +158,13 @@ function Login() {
           <LoginButton type="submit">로그인</LoginButton>
           <BottomLinkWrapper>
             {/* 나중에 경로 채우기 */}
-            <Link href='/user/findingid' passHref legacyBehavior><PageLinkText>아이디 찾기</PageLinkText></Link>
-            <Link href='/user/findingpw' passHref legacyBehavior><PageLinkText>비밀번호 찾기</PageLinkText></Link>
+            <Link href='/auth/findingid' passHref legacyBehavior><PageLinkText>아이디 찾기</PageLinkText></Link>
+            <Link href='/auth/findingpw' passHref legacyBehavior><PageLinkText>비밀번호 찾기</PageLinkText></Link>
             <Link href='/auth/signup' passHref legacyBehavior><PageLinkText>회원가입</PageLinkText></Link>
           </BottomLinkWrapper>
         </form>
-      </Card>
-    </Container>
+      </LoginCard>
+    </LoginContainer>
   );
 }
 

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React, { useCallback, useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 
 const domainList = ['hansei.ac.kr', 'gmail.com'];
@@ -76,9 +76,8 @@ const FieldWapper=styled.div`
     min-width:200px;
     width:557px;
 `;
-
-export const SignUpButton = styled.button`
-  background-color: #000000;
+export const buttonCss=css`
+   background-color: #000000;
   color: #fff;
   padding: 12px;
   border: none;
@@ -90,6 +89,9 @@ export const SignUpButton = styled.button`
   &:hover {
     background-color: #1a73e8;
   }
+`
+export const SignUpButton = styled.button`
+ ${buttonCss}
 `;
 const PageLinkText = styled.span`
   color: #808080;
@@ -147,14 +149,20 @@ function SignUp() {
     
     const response = await fetch(apiURL, options);
     if(response.ok){
+      
         switch(response.status){
         case 201:
             router.push(await response.text() )
             break;
-        case 200:
-            const result = await response.json();
+        
         }
         }else{
+          switch(response.status){
+            case 409:
+            const result = await response.json();
+            alert(result.error)
+            break;
+          }
         }
     },[])
 

--- a/src/components/board/BoardHeader.tsx
+++ b/src/components/board/BoardHeader.tsx
@@ -1,0 +1,67 @@
+import LoginInfo from "@/components/main/LoginInfo";
+import { TopBox, Logo, ButtonWrapper } from "@/components/main/Mainpage";
+import Sublist2 from "@/components/main/Sublist2";
+import Link from "next/link";
+import { SignUpButton } from "@/components/auth/SignUp";
+
+const majorlist = [
+    { menuName: '신학부', 
+    items: [
+      { name: '신학과' },
+      { name: '기독교교육상담학과' }
+    ]},
+    { menuName: '인문사화과학부', 
+    items: [
+      { name: '미디어영상광고학과' },
+      { name: '경영학과' },
+      { name: '경찰행정학과' },
+      { name: '국제관광학과' },
+      { name: '영어학과' },
+      { name: '중국어학과' }
+    ]},
+    { menuName: 'IT학부', 
+    items: [
+      { name: '컴퓨터공학과' },
+      { name: 'ICT융합학과' },
+      { name: '산업보안학과' }
+    ]},
+    { menuName: '간호복지학부', 
+    items: [
+      { name: '간호학과' },
+      { name: '사회복지학과' }
+    ]},
+    { menuName: '예술학부', 
+    items: [
+      { name: '음악학과' },
+      { name: '공연예술학과' }
+    ]},
+    { menuName: '디자인학부', 
+    items: [
+      { name: '시각정보디자인학과' },
+      { name: '실내건축디자인학과' },
+      { name: '섬유패션디자인학과' }
+    ]},
+    { menuName: '계약학과', 
+    items: [
+      { name: '보건복지 사회적기업학과' },
+      { name: '보건융합 사회적경제학과' },
+      { name: '스마트콘텐츠마케팅학과' }
+    ]}
+  ];
+  
+
+function BoardHeader() {
+    return <TopBox>
+      <Link href={'/'}><Logo width={75} height={75} alt='' src="/logo2.png" /></Link>
+      {majorlist.map(({ menuName, items }) => (
+        <Sublist2 key={menuName} title={items} menuName={menuName} />
+      ))}
+      <ButtonWrapper>요청하기</ButtonWrapper>
+      <LoginInfo />
+    </TopBox>;
+  }
+
+  export default BoardHeader;
+
+
+  

--- a/src/components/board/BoardPageBar.tsx
+++ b/src/components/board/BoardPageBar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction:row;
+  align-items: center;
+`;
+
+const Number = styled.div<{active:boolean}>`
+  padding: 10px;
+  font-weight: ${({ active }) => (active ? 'bold' : 'normal')};
+  cursor: pointer;
+`;
+type Props={
+    currentPage:number, 
+    totalPages?:number, 
+    onClick:(number:number)=>void,
+}
+
+const BoardPageBar = ({ currentPage, totalPages=10, onClick }:Props) => {
+  const numbers = Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  return (
+    <Container>
+      {numbers.map(number => (
+        <Number
+          key={number}
+          active={number === currentPage}
+          onClick={() => onClick(number)}
+        >
+          {number}
+        </Number>
+      ))}
+    </Container>
+  );
+};
+
+export default BoardPageBar;

--- a/src/components/board/PartBoard.tsx
+++ b/src/components/board/PartBoard.tsx
@@ -1,11 +1,100 @@
 import styled from 'styled-components';
 import Link from 'next/link';
+import BoardPageBar from './BoardPageBar';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { SignUpButton, buttonCss } from '../auth/SignUp';
+
+
+
+
+const Div = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  margin-top: 20px;
+`;
+
+const DivRow = styled.div`
+  display: block;
+  flex-direction: row;
+  width:100%;
+  
+  justify-content: center;
+  align-items: center;
+  border: 2px solid #9C9C9C;
+  border-left: none;
+  border-right: none;
+`;
+
+const DivCell = styled.div`
+  flex:1;
+  padding: 16px 0 14px;
+  text-decoration-line: none;
+  text-align: center;
+
+  &:first-child {
+    border-left: 0px;
+  }
+
+  &:last-child {
+    border-right: 0px;
+  }
+`;
+
+const DivHeader = styled.div`
+  flex:1;
+  height: 48px;
+  padding: 16px 0 14px;
+  border: 2px solid #9C9C9C;
+  border-top: 2px solid #9C9C9C;
+  border-left: none;
+  border-right: none;
+  background-color: #E5F7FF;
+  border-bottom: 2px solid #9C9C9C;
+
+  &:first-child {
+    border-left: 2px solid #9C9C9C;
+  }
+
+  &:last-child {
+    border-right: 2px solid #9C9C9C;
+  }
+`;
+
+const DivTable = styled.div`
+  width: 100%;
+  min-width: 850px;
+  margin: 0 auto;
+  margin-top: 20px;
+  border-collapse: collapse;
+  border: none;
+  text-align: center;
+`;
+
+
+
+
+
 
 const InnerBox = styled.div`
   display: flex;
+  flex-direction:row;
 `;
 
-const Div = styled.div`
+
+const Divvv = styled.div`
+   display: flex;
+  flex-direction: row;
+  width:100%;
+  
+  justify-content: center;
+  align-items: center;
+  border: 2px solid #9C9C9C;
+  border-left: none;
+  border-right: none;;
+`;
+
+const Divv = styled.div`
   margin: 0 auto;
 `;
 
@@ -21,114 +110,90 @@ const Explain = styled.p`
   font-size:0.8rem;
 `;
 
-const Table = styled.table`
- width: 100%;
- min-width:850px;
- margin: 0 auto;
- margin-top: 20px;
-border-collapse: collapse;
-border: none;
-text-align: center;
+
+const BoardPostWrite=styled(Link)`
+  justify-content:flex-end;
+  ${buttonCss}{
+    
+  }
 `;
+const BoardBottomBox=styled(InnerBox)`
+  justify-content:flex-end;
+`
 
-const Tbody = styled.tbody`
- border: none;
-`;
-
-
-interface Post{ // 게시글의 타입
-  id: number;
+export interface Post{ // 게시글의 타입
+  postid: number;
   title: string;
-  coment: number;
-  author: string;
+  content?:string;
+  coment?: number;
+  author: string; 
   date: string;
   views?: number;
   likes?: number;
   timestamp?: number;
 };
 
-const Td = styled.td` // 게시글의 내용 부분
-  height: 48px;
-  padding: 16px 0 14px;
-  border: 2px solid #9C9C9C;
-  border-left: none;
-  border-right: none;
-
-  &:first-child {
-    border-left: 2px solid #9C9C9C;
-  }
-  &:last-child {
-    border-right: 2px solid #9C9C9C;
-  }
-
-  a {
-  text-decoration: none;
-  color: inherit;
-}
-`;
-
-const Th = styled.th` // 게시글의 윗 머리 부분
-  height: 48px;
-  padding: 16px 0 14px;
-  border: 2px solid #9C9C9C;
-  border-top: 2px solid #9C9C9C;
-  border-left: none;
-  border-right: none; 
-  background-color: #E5F7FF; 
-  border-bottom: 2px solid #9C9C9C;
-  &:first-child {
-    border-left: 2px solid #9C9C9C;   
-  }
-
-  &:last-child {
-    border-right: 2px solid #9C9C9C;
-  }
+const TableLink=styled(Link)`
+  display:flex;
+  flex-direction:row;
+  text-decoration:none;
+  color:black;
 `;
 
 type Props={
-    data?:Post[], 
-    boardTitle:boolean
+    data?:Post[],
+    boardHeader?:boolean,
+    boardTitle?:string,
+    handlePost:any,
 }
 
-function Board ({boardTitle=true,data=[]}:Props) {
+function PartBoard ({boardHeader=true,data: PostsData=[],boardTitle, handlePost}:Props) {
     return (  
       <InnerBox>                 
-      <Div>
-        {boardTitle&&(<>
-        <Title>자유게시판</Title>
-        <Explain>다과회의 자유게시판입니다.</Explain>
+<Divv>
+        {boardHeader&&(<>
+        <Title>{boardTitle}게시판</Title>
+        <Explain>{boardTitle}게시판입니다.</Explain>
         </>)}
-        <Table>
-        <Tbody>
-          <tr>
-            <Th>번호</Th>
-            <Th>제목</Th>
-            <Th>작성자</Th>
-            <Th>날짜</Th>
-            <Th>조회수</Th>
-            <Th>좋아요</Th>
-          </tr>
-          {data?.map((post) => (
-          <tr key={post.id}>
-            <Td>{post.id}</Td>
-            <Td>
-              <Link href={`/post/${post.id}`} passHref>
-                {post.title}[{post.coment}]
-              </Link>
-            </Td>
-            <Td>{post.author}</Td>
-            <Td>{post.date}</Td>
-            <Td>{post.views}</Td>
-            <Td>{post.likes}</Td>
-          </tr>
-        ))}
-          
-        </Tbody>
-        </Table>
-      </Div>
+        
+        <DivTable>
+          <Divvv>
+            <DivHeader>번호</DivHeader>
+            <DivHeader>제목</DivHeader>
+            <DivHeader>작성자</DivHeader>
+            <DivHeader>날짜</DivHeader>
+            <DivHeader>조회수</DivHeader>
+            <DivHeader>좋아요</DivHeader>
+          </Divvv>
+          {PostsData[0]?PostsData.map((data) =>(
+            <DivRow key={data.postid}>
+          <TableLink onClick={()=>{handlePost(data.postid)}} href={{pathname:`/post/[id]`,query:{id:data.postid}}}>
+              <DivCell>{data.postid}</DivCell>
+              <DivCell>
+                {data.title}
+                {data.coment && `[${data.coment}]`}
+              </DivCell>
+              <DivCell>{data.author}</DivCell>
+              <DivCell>{data.date}</DivCell>
+              <DivCell>{data.views || 0}</DivCell>
+              <DivCell>{data.likes || 0}</DivCell>
+          </TableLink>
+          <Div/>
+            </DivRow>
+          )):<DivRow>
+            <DivCell>더이상 글이 없습니다!</DivCell>
+            <DivCell>새로운 글로 채워주세요</DivCell>
+            </DivRow>}
+            <BoardBottomBox>
+            <BoardPostWrite href={'/post'} >글쓰기</BoardPostWrite>
+            </BoardBottomBox>
+            
+        </DivTable>
+      </Divv>
+      
       </InnerBox>
      
      );
   }
   
-  export default Board ;
+  export default PartBoard ;

--- a/src/components/main/LoginInfo.tsx
+++ b/src/components/main/LoginInfo.tsx
@@ -1,5 +1,5 @@
 import { getUserInfo } from '@/pages/mainpage';
-import { useQuery } from '@tanstack/react-query';
+import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
 import router from 'next/router';
 import React, { useEffect, useState } from 'react';
 import Link  from 'next/link';
@@ -7,17 +7,20 @@ import styled from 'styled-components';
 import { hasCookie } from 'cookies-next';
 
 function LoginInfo() {
-  const { data, isFetched, isStale,isError,isFetchedAfterMount, remove } = useQuery({ queryKey: ['userInfo'],staleTime:30000 ,queryFn:getUserInfo, retryDelay:30000, initialData:null, initialDataUpdatedAt:0})
-
-    const [isLogIn, setIsLogIn]=useState<boolean>((isStale||isFetched));
+  const { data, isFetched, isStale,isSuccess, remove } = useQuery({ queryKey: ['userInfo'],staleTime:300000 ,queryFn:getUserInfo, retryDelay:30000, initialData:null, initialDataUpdatedAt:0})
+    const [isLogIn, setIsLogIn]=useState<boolean>((isFetched||isStale));
+    const queryClient=useQueryClient()
     const handleLogout = async () => {
         const res = await fetch(`/api/${process.env.NEXT_PUBLIC_VAPI}/login`,{method:"DELETE"})
         if(res.status===404){
-          remove();
+          queryClient.invalidateQueries(['userInfo'])
           setIsLogIn(false)
         }
         if(res.status===204){
-          remove();
+          queryClient.invalidateQueries(['userInfo'])
+          setIsLogIn(false)
+        }else{
+          queryClient.invalidateQueries(['userInfo'])
           setIsLogIn(false)
         }
 
@@ -37,7 +40,7 @@ function LoginInfo() {
       
     return (
         <LoginContainer>
-          {isLogIn?(
+          {isLogIn&&data?(
             <>
               <Link href={'/mypage'}><Username>{data?.id}</Username></Link>
               <LoginButton onClick={handleLogout}>로그아웃</LoginButton>

--- a/src/components/main/Mainpage.tsx
+++ b/src/components/main/Mainpage.tsx
@@ -9,6 +9,7 @@ import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteCookie, getCookie, hasCookie, setCookie } from 'cookies-next';
 import { useRouter } from 'next/router';
 import LoginInfo from './LoginInfo';
+import { Post } from '../board/PartBoard';
 
 interface SubMenuProps {
   isOpen: boolean;
@@ -27,10 +28,14 @@ const TwoBox = styled.div` /*CategoryBox3, 4 묶음*/
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  margin-right:20px;
+  @media screen and (max-width: 1120px){
+    order:3;
+  }
 `;
 
-const TopBox = styled.div`
-  position: absolute;
+export const TopBox = styled.div`
+  position: relative;
   width: 100%;
   height: 70px;
   top: 0;
@@ -41,11 +46,11 @@ const TopBox = styled.div`
   background-color: black;
 `;
 
-const Logo = styled(Image)`
+export const Logo = styled(Image)`
   margin-left: 30px;
 `;
 
-const ButtonWrapper = styled.div`
+export const ButtonWrapper = styled.div`
   margin: 0 0.5rem;
   width: 6.875rem;
   height: 2.5rem;
@@ -60,6 +65,7 @@ const ButtonWrapper = styled.div`
   font-size: 0.85rem;
   font-weight: bold;
   position: relative;
+  word-break:keep-all;
 
   &:hover {
     .submenu {
@@ -79,36 +85,41 @@ const SubMenu = styled.div<SubMenuProps>`
   background-color: #F5FEFF;
 `;
 
-const SubMenuList = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin: 0;
-`;
 
-const SubMenuItem = styled.li`
-  font-size: 0.85rem;
-  padding: 0.25rem 0;
-`;
 
 const BottomWrapper = styled.div`
   display: flex;
-  justify-content: center;
+  width:100%;
+  justify-content: space-around;
   margin-top: 4rem;
+  flex-direction:row;
+  @media screen and (max-width: 1120px) {
+    flex-direction:row;
+    justify-content:center;
+    flex-wrap: wrap;
+    justify-content:'space-between'
+  }
 `;
 
 const CategoryBox = styled.div`
   background-color: #F6FFF1;
   height: 687px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  width:480px;
+  display: block;
   justify-content: center;
   border: solid gray;
   border-radius: 0.5rem;
-  margin-right: 3rem;
+  padding:20px;
+  margin-right: 40px;
   margin-top: 70px;
   padding-left: 50px;
   padding-right: 50px;
+  margin-left:40px;
+  margin-right:40px;
+  @media screen and (max-width: 1120px) {
+    order:0;
+    width:800px;
+  }
   `;
  
 const CategoryBox2 = styled.div`
@@ -116,13 +127,19 @@ const CategoryBox2 = styled.div`
   height: 20.75rem;
   background-color: #F6FFF1;
   display: flex;
+  padding:20px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   border: solid gray;
   border-radius: 0.5rem;
-  margin-right: 3rem;
+  margin-right: 60px;
+  margin-left:20px;
   margin-top: 70px;
+  @media screen and (max-width: 1120px) {
+    margin-right: 120px;
+    order:1
+  }
 `;
 
  const CategoryTitle1 = styled.div`
@@ -141,7 +158,8 @@ const CategoryBox3 = styled.div`
   justify-content: center;
   border: solid gray;
   border-radius: 0.5rem;
-  margin-right: 3rem;
+  margin-right: 20px;
+  margin-left: 40px;
   margin-top: 70px;
 `;
 
@@ -161,7 +179,8 @@ const CategoryBox4 = styled.div`
   justify-content: center;
   border: solid gray;
   border-radius: 0.5rem;
-  margin-right: 3rem;
+  margin-right: auto;
+  margin-left:auto;
   margin-top: 50px;
 `;
 
@@ -175,13 +194,17 @@ const InnerBox = styled(Link)`
   text-decoration-line:none;
   
   font-size: smaller;
-  width: 250px;
+  width: 350px;
   height: 30px;
   background-color: #FFFFF2;
   margin-top: 10px;
   margin-bottom: 10px; /* 각 InnerBox의 아래쪽 간격을 0.5rem으로 설정 */
   border-radius: 15px;
   padding: 3px;
+  color:black;
+  @media screen and (max-width: 1120px) {
+    width:600px;
+  }
 `;
 
 const InnerBox2 = styled.div`
@@ -336,8 +359,11 @@ const majorlist7 = [
   {name : '보건융합 사회적경제학과'},
   {name : '스마트콘텐츠마케팅학과'}
 ]
+type Props={
+  freeData:Post[];
+}
 
-const Mainpage= () => {
+const Mainpage= ({freeData}:Props) => {
   const router= useRouter()
   const [subMenuOpen, setSubMenuOpen] = useState();
 
@@ -360,12 +386,6 @@ const Mainpage= () => {
         </TopBox>
 
       <BottomWrapper>
-        <CategoryBox>
-        <CategoryTitle> 자유게시판 </CategoryTitle>
-        {frontdata.map((data)=> <InnerBox key={data.title} href={data.url}>{data.title}</InnerBox>)}
-        <Link href={'/board'}><RequestButton>더보기</RequestButton></Link>
-        </CategoryBox>
-
         <CategoryBox2>
         <CategoryTitle1> 오늘의 일정 </CategoryTitle1>
         <InnerBox2>✔ 투자론 6주차 과제 제출</InnerBox2>
@@ -373,6 +393,7 @@ const Mainpage= () => {
         <InnerBox2>✔ 비교과프로그램 수강</InnerBox2>
         </CategoryBox2>
 
+        
       <TwoBox>
         <CategoryBox3>
         <CategoryTitle2> 별점순 </CategoryTitle2>
@@ -383,14 +404,31 @@ const Mainpage= () => {
 
         <CategoryBox4>
         <CategoryTitle3> 활동순 </CategoryTitle3>
+        <InnerBox4 width={200} href={'/a'}>정지훈</InnerBox4>{/*이정도는..*/}
         <InnerBox4 width={200} href={'/a'}>변혜림</InnerBox4>
         <InnerBox4 width={200} href={'/a'}>박동주</InnerBox4>
-        <InnerBox4 width={200} href={'/a'}>정지훈</InnerBox4>
         </CategoryBox4>
         </TwoBox>
+
+        <CategoryBox>
+        <BoxBox>
+        <CategoryTitle> 자유게시판 </CategoryTitle>
+
+        {freeData?.map((data:Post)=> <InnerBox key={data.postid} href={`post/${data.postid}`}>{data.title}</InnerBox>)}
+        <Link href={'/board'}><RequestButton>더보기</RequestButton></Link>
+        
+        </BoxBox>
+        </CategoryBox>
       </BottomWrapper>
     </MainContainer>
   );
 };
 
 export default Mainpage;
+
+const BoxBox=styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`

--- a/src/components/main/Sublist2.tsx
+++ b/src/components/main/Sublist2.tsx
@@ -33,6 +33,7 @@ const ButtonWrapper = styled.div`
   font-size: 0.85rem;
   font-weight: bold;
   position: relative;
+  word-break:keep-all;
 
   &:hover {
     .submenu {

--- a/src/components/post/PostEditor.tsx
+++ b/src/components/post/PostEditor.tsx
@@ -5,7 +5,9 @@ import '@toast-ui/editor/dist/i18n/ko-kr';
 import styled from 'styled-components';
 
 const EditorWraper= styled.div`
-  width:100%;
+  max-width:823px;
+  width:630px;
+
 `
 type Props={
   content:string,
@@ -23,7 +25,14 @@ function PostEditor({content ='', onChange, editorRef}:Props) {
       previewStyle="vertical"
       placeholder="글을 작성해주세요"
       height="auto"
-      minHeight='200px'
+      minHeight='400px'
+      toolbarItems={[
+        ['heading', 'bold', 'italic', 'strike'],
+        ['hr', 'quote'],
+        ['ul', 'ol', 'task'],
+        ['table', 'link'],
+        ['code'],
+    ]}
       hideModeSwitch={true}
       onChange={()=>onChange(editorRef.current?.getInstance().getMarkdown())}
       initialEditType="wysiwyg"

--- a/src/components/post/PostForm.tsx
+++ b/src/components/post/PostForm.tsx
@@ -4,8 +4,16 @@ import styled from 'styled-components';
 import { Path, useForm, UseFormRegister, SubmitHandler } from "react-hook-form";
 import { useRouter } from 'next/router';
 import { SignUpButton } from '../auth/SignUp';
+import BoardHeader from '../board/BoardHeader';
 
-const EditorSSR = dynamic(()=>import('@/components/post/PostEditor'),{ssr:false});
+const LoadingArea=styled.div`
+  max-width:823px;
+  width:630px;
+  min-height:400px;
+  background-color:white;
+`;
+
+const EditorSSR = dynamic(()=>import('@/components/post/PostEditor'),{ssr:false, loading: () => <LoadingArea></LoadingArea>});
 
 
 interface IPostInput {
@@ -13,15 +21,9 @@ interface IPostInput {
   content:string;
   tag?:string;
 }
-  
-type InputProps = {
-  label: Path<IPostInput>;
-  register: UseFormRegister<IPostInput>;
-  required: boolean;
-};
 
 const PostWriteContainer=styled.div`
-    display:block;
+    display:flex;
     justify-content:center;
     align-items:center;
     flex-direction:column;
@@ -35,11 +37,15 @@ const TextField = styled.input`
   width: 100%;
   padding: 4px;
   margin-top:8px;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
   border: 1px solid #bec3c7;
   border-left:0px;
+  font-size:16px;
   border-right:0px;
   box-sizing:border-box;
+  &:focus-visible{
+    outline-style:none;
+  }
 `;
 const StyledLabel=styled.label`
 `
@@ -90,23 +96,25 @@ function post() {
     const apiURL=`/api/${process.env.NEXT_PUBLIC_VAPI}/post`
  
     const response = await fetch(apiURL, options);
-    if(response.ok){
       try {
-        switch(response.status){
-          case 201:
-            const {url}= await response.json()
-            router.push(url)
-            break;
-          case 200:
-            const result = await response.text();
-            break;
+        if(response.ok){
+          const result= await response.text()
+          switch(response.status){
+            case 201:
+              const url = JSON.parse(result)
+              router.push(url.url)
+              break;
+            case 200:
+
+              break;
+            default:;
+          }
+          } else{
+            alert("권한이없습니다")
+            router.back()
           }
       } catch (error) {
         console.log(error)
-      }
-      
-      }else{
-        setErrorText("이메일 또는 비밀번호를 확인하세요");
       }
   },[]) 
    
@@ -114,12 +122,11 @@ function post() {
    
      
     return (
+      <>
+      <BoardHeader/>
       <PostWriteContainer>
-      <div>
-        둘만한 헤더가 있으면 위치할 영역 작성중인 게시판, 바로가기등
-      </div>
-      <h2>글쓰기</h2>
         <form onSubmit={handleSubmit(onSubmit)}>
+        <TempHeader>{}게시판 글쓰기</TempHeader>
             <PostHeader>
               <StyledLabel >
                 <TextField type='text' placeholder='글제목'
@@ -135,7 +142,14 @@ function post() {
           
         </PostBottom>
       </PostWriteContainer>
+      </>
     );
 }
 
 export default post;
+
+const TempHeader= styled.div`
+  margin-top:18px;
+  margin-bottom:18px;
+  font-size:20px;
+`

--- a/src/components/post/PostViewer.tsx
+++ b/src/components/post/PostViewer.tsx
@@ -1,19 +1,28 @@
 import { Viewer } from '@toast-ui/react-editor';
 import dynamic from 'next/dynamic';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 
 type Props = {
     content:string,
-
 };
-const ViewerSSR =dynamic(()=>import("@toast-ui/react-editor").then((mod)=>mod.Viewer) ,{ssr:false});
+
+
+
 function PostViewer({content=''}:Props) {
-    
+    const [newContent, setNewContent]=useState(content)
+    const plz=useRef<any>(null)
+    useEffect(()=>{
+        console.log(plz.current)
+        plz.current.getInstance().setMarkdown(content)
+    },[content])
+    // const viewUpdate=()=>{
+        
+    // }
     return (
         <ViewerWapper>
-            <ViewerSSR initialValue={content}/>
+            <Viewer initialValue={content} ref={plz} />
         </ViewerWapper>
     );
 }

--- a/src/hook/useParsingDate.ts
+++ b/src/hook/useParsingDate.ts
@@ -28,7 +28,6 @@ import React, { useEffect, useState } from 'react';
             formattedDate = isToday
             ? new Date(postDate).toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit' })
             : new Date(postDate).toLocaleDateString('ko-KR', { month: 'numeric', day: 'numeric' });
-            console.log(formattedDate)
             
         }else{
             formattedDate=dateString;

--- a/src/hook/usePostsData.ts
+++ b/src/hook/usePostsData.ts
@@ -1,0 +1,28 @@
+import { Post } from "@/components/board/PartBoard"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+
+
+export async function getPostsData(pageNumber:number|null|undefined, count:number|null|undefined){
+    const APIURL=`${process.env.NEXT_PUBLIC_URL}/api/${process.env.NEXT_PUBLIC_VAPI}/post?pages=${pageNumber||1}${count&&`&licf=${count}`}`
+    const response = await fetch(APIURL)
+    try {
+        if(response.ok){
+            const result = await response.json()
+            return result   
+        }else{
+            throw new Error()
+        }
+    } catch (error) {
+        console.log("에러")
+    }
+    
+  }
+
+export const useGetPostsData = ({pageNumber, count}:{pageNumber?:number|null|undefined, count?:number|null|undefined}):[postsData:any,isLoading:boolean,error:any] =>{
+    const queryClient = useQueryClient()
+const { data:postsData, isLoading, isError } = useQuery<Post[]>({queryKey:['viewPosts',pageNumber,count], queryFn:()=>getPostsData(pageNumber,count), staleTime:600000});
+  
+
+return [postsData,isLoading,isError];
+}

--- a/src/pages/api/v1/auth.ts
+++ b/src/pages/api/v1/auth.ts
@@ -1,0 +1,68 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getCookie, hasCookie, setCookie, deleteCookie } from 'cookies-next';
+
+const LOGINAPIURL='/user/join'
+const APIURL= `${process.env.APIENDPOINT}${LOGINAPIURL}` as string
+type Data = {
+
+    // succeed:boolean
+    // result?:any,
+    // user?:{
+    //   userId?:number,
+    //   username:string,
+    // }
+    // error?:string
+}
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<Data>
+  ) 
+  {
+      //회원정보
+      if (req.method === 'POST') {
+            const id ={id:req.body.userid};
+            const bodyData=JSON.stringify(id)
+            const options = {
+            method: 'GET',
+            headers: {
+            },
+            };
+            try {
+            const response = await fetch(`${APIURL}?userid=${id.id as string}`, options);
+
+            try {
+                if(response.ok)
+                {
+                    const result = await response.json();
+                    res.status(200).end()
+                    console.log(result.userpw)
+                }else{
+                const result = await response.json();
+        
+                console.log(result," 백엔드 요청에러")
+                res.status(404).end()
+                }
+            } catch (error) {
+                console.log(error,'데이터 파싱에러')
+                res.status(401).end()
+            }
+            
+            
+            } catch (error) {
+            console.log(error,"백엔드 연결 실패")
+            if(process.env.NODE_ENV=='development'){
+                console.log("임시데이터 반환")
+                res.status(400).end()
+            }else{
+                    res.status(400).end()
+                }
+                
+                }
+          } else {
+          console.log("비정상접근");
+          res.status(400).end()
+          
+        }
+    
+  }

--- a/src/pages/api/v1/mypage.ts
+++ b/src/pages/api/v1/mypage.ts
@@ -36,7 +36,7 @@ export default async function handler(
                 studentId:result.user.studentId,
                 name:result.user.firstName+result.user.lastName,
               }
-              console.log(passResult)
+
               res.status(200).json(passResult);
             }else{
               console.log("백엔드 인증실패")

--- a/src/pages/api/v1/post/[id].ts
+++ b/src/pages/api/v1/post/[id].ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { getCookie, hasCookie, setCookie, deleteCookie } from 'cookies-next';
 
-const LOGINAPIURL='/post'
-const APIURL= `${process.env.APIENDPOINT}${LOGINAPIURL}` as string
+const POSTAPIURL='/post'
+const APIURL= `${process.env.APIENDPOINT}${POSTAPIURL}` as string
 type Data = {
 
     // succeed:boolean
@@ -20,13 +20,14 @@ export default async function handler(
   ) 
   {
     const seesionIDcookie = `sid=${getCookie('sid',{req,res}) as string}`;
-      console.log("게시글요청");
+    const {id} =req.query  
+    console.log("게시글요청");
       // console.log(reqDataJSON)
       // if(req.headers.location){
       //   res.redirect(req.headers.location)
       // }
       if (req.method === 'GET'){
-        const {id} =req.query
+        
         console.log('게시글보기')
             const options = {
               method:'get',
@@ -66,7 +67,6 @@ export default async function handler(
             } catch (error) {}
           }else if(req.method==='DELETE'){
           console.log("게시글 삭제응답")
-          const seesionIDcookie = `sid=${getCookie('sid',{req,res}) as string}`;
           const options = {
             method:'DELETE',
             headers:{
@@ -75,12 +75,14 @@ export default async function handler(
             
           };
           try {
-            const response = await fetch(APIURL, options);
+            const response = await fetch(`${APIURL}/${id}`, options);
             try {
               if(response.ok)
               {
-             
+                console.log("게시글 삭제성공")
+                res.status(200).end()
               }else{
+                console.log("게시글삭제실패 ")
                 res.status(404).end();
               }
             } catch (error) {

--- a/src/pages/api/v1/signup.ts
+++ b/src/pages/api/v1/signup.ts
@@ -54,7 +54,7 @@ export default async function handler(
                 const result = await response.json();
         
                 console.log(result," 백엔드 요청에러")
-                res.status(500).end()
+                res.status(409).json({error:result.message})
                 }
             } catch (error) {
                 console.log(error,'데이터 파싱에러')
@@ -73,8 +73,7 @@ export default async function handler(
                 
                 }
           }else if(req.method==='DELETE'){
-          console.log("게시글 삭제응답")
-          const seesionIDcookie = `sid=${getCookie('sid',{req,res}) as string}`;
+          console.log("회원탈퇴요청", req.body)
           const options = {
             method:'DELETE',
             headers:{
@@ -87,9 +86,20 @@ export default async function handler(
             try {
               if(response.ok)
               {
-             
+                const result = await response.json();
+                    console.log(result.message)
+                    switch(response.status){
+                      case 200:
+                        deleteCookie('sid',{req,res})
+                        res.redirect(201,'/login')
+                        break;
+                      case 403:
+                        res.status(404).json({error:result.message})
+                        break;
+                    }
+  
               }else{
-                res.status(404).end();
+                res.status(404).json({error:"회원탈퇴에 실패했습니다"});
               }
             } catch (error) {
                 console.log('데이터 파싱에러')

--- a/src/pages/auth/findingid.tsx
+++ b/src/pages/auth/findingid.tsx
@@ -1,10 +1,9 @@
+import FindUser from '@/components/auth/FindUser';
 import React from 'react';
 
 function findingId() {
     return (
-        <div>
-            대충 아이디찾기
-        </div>
+        <FindUser findType='id'/>
     );
 }
 

--- a/src/pages/auth/findingpw.tsx
+++ b/src/pages/auth/findingpw.tsx
@@ -1,10 +1,10 @@
+import FindUser from '@/components/auth/FindUser';
 import React from 'react';
 
 function findingpw() {
     return (
-        <div>
-            대충 비밀번호 찾기
-        </div>
+        
+        <FindUser findType='pw'/>
     );
 }
 

--- a/src/pages/board/OldBoard.tsx
+++ b/src/pages/board/OldBoard.tsx
@@ -1,40 +1,12 @@
-import BoardPageBar from "@/components/board/BoardPageBar";
-import PartBoard, { Post } from "@/components/board/PartBoard";
-import { useGetPostsData } from "@/hook/usePostsData";
+import Board from "@/components/Board";
 import { getCookie } from "cookies-next";
 import { GetServerSidePropsContext } from "next";
-import { useRouter } from "next/router";
-import { useState } from "react";
-import { PostViewContainer } from "post[dynamic]";
-import BoardHeader from "@/components/board/BoardHeader";
 
 
-
-
-export default function newBoard() {
-  const router = useRouter();
-  const [currentPage, setCurrentPage] = useState(1);
-  const [data, isLoading, error ]= useGetPostsData({pageNumber:currentPage,count:10})
-  const handlePageClick = (number :number) => {
-    
-    router.push({query:{...router.query}},undefined, { shallow: true});
-
-    setCurrentPage(number);
-    
-  };
-  function handlePostShow(postid:string|number|null): void{
-    
-    const show = data.find((post:any)=>post.postid===postid)
-    //console.log(show)
-    ;
-  }
+export default function Home() {
   return (
     <>
-    <BoardHeader/>
-    <PostViewContainer>
- {!isLoading&&(<PartBoard boardHeader={true} data={data} boardTitle="자유" handlePost={handlePostShow} />)}
-      <BoardPageBar currentPage={currentPage} onClick={handlePageClick} />
-    </PostViewContainer >
+ <Board data={[]}/>
     </>
   )
 }
@@ -61,11 +33,20 @@ export const getServerSideProps
  
 };
 
-
+interface Post{ // 게시글의 타입
+  id: number;
+  title: string;
+  coment: number;
+  author: string;
+  date: string;
+  views: number;
+  likes: number;
+  timestamp: number;
+};
 
 const posts: Post[] = [
   {
-    postid: 1,
+    id: 1,
     title: '오늘 진짜 귀여운 고양이 봤어!!',
     coment:5,
     author: '박동주',
@@ -75,7 +56,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 2,
+    id: 2,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -85,7 +66,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 3,
+    id: 3,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -95,7 +76,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 4,
+    id: 4,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -105,7 +86,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 5,
+    id: 5,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -115,7 +96,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 6,
+    id: 6,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -125,7 +106,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 7,
+    id: 7,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -135,7 +116,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 8,
+    id: 8,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -145,7 +126,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 9,
+    id: 9,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -155,7 +136,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 10,
+    id: 10,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -165,7 +146,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 11,
+    id: 11,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -175,7 +156,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 12,
+    id: 12,
     title: '오늘 ',
     coment:5,
     author: '박동주',
@@ -185,7 +166,7 @@ const posts: Post[] = [
     timestamp: Date.now(),
   },
   {
-    postid: 13,
+    id: 13,
     title: '이번주 학식 완전 최고야!!',
     coment:5,
     author: '박동주',
@@ -198,7 +179,4 @@ const posts: Post[] = [
 ];
 
 
-
-const sortedPosts = [...posts].sort((a, b) => b.postid - a.postid);
-
-
+const sortedPosts = [...posts].sort((a, b) => b.id - a.id);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,7 +8,7 @@ import { useEffect } from 'react';
 export default function Home() {
   const router=useRouter();
   useEffect(()=>{
-    router.push('/login')
+    router.replace('/login')
   },[])
   
   return (

--- a/src/pages/mainpage.tsx
+++ b/src/pages/mainpage.tsx
@@ -1,6 +1,8 @@
 import Mainpage from '@/components/main/Mainpage';
 import React from 'react';
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query'
+import { useGetPostsData } from '@/hook/usePostsData';
+import { Post } from '@/components/board/PartBoard';
 
 export async function getUserInfo(){
     const APIURL=`${process.env.NEXT_PUBLIC_URL}/api/${process.env.NEXT_PUBLIC_VAPI}/mypage`
@@ -14,14 +16,15 @@ export async function getUserInfo(){
             throw new Error()
         }
     } catch (error) {
-        console.log("에러")
+        return null
     }
     
 }
 
 function mainpage() {
+    const [freeData, isLoading, error ]= useGetPostsData({count:10});
     return (
-        <Mainpage />
+        <Mainpage freeData={freeData}/>
     );
 }
 // export async function getStaticProps() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "post[dynamic]":["./src/pages/post/[id]"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
회원가입 완료시 자동로그인 후 리다이렉트 기능 고침
수동 배포과정을 단축하기 위한 스크립트 작성
중복 아이디로 회원가입시 오류를 반환하도록 수정
회원탈퇴 기능 백엔드/프론트 구현 
게시글 삭제기능 백엔드/프론트 구현
게시글 조회시 동적 가져오기에 의한 렌더링이 최소화되도록 구조 변경
게시글 목록을 고정 단위로 페이징해서 가져올수 있도록 API 수정
게시판 기능 영역별로 나눠서 리팩토링
회원 비밀번호 찾기 API와 임시페이지 구현
로그아웃 로그인 반복시 로그인 상태가 제대로 표시안되던 버그 수정
게시글 삭제시 아이디만 같으면 안되고 같은 회원만 삭제할수있도록 게시글 필드에 사용자 UID 필드추가
게시글 목록 조회시 useQuery를 감싼 커스텀 hook을 사용하도록 리팩토링
기존자유게시판 페이지는 oldBoard로 변경하고 재활용해서 새로만듬 
자유게시판에 게시글목록 조회 API 연동
메인페이지에 자유게시판 글목록 연동
메인페이지 스타일링 변경
마이페이지 스타일링 변경
메인페이지의 상단헤더를 공통컴포넌트로 분리
삭제버튼은 작성자한테만 보임
에디터가 로드되는 동안 임시컴포넌트 표시
기타 사소한 스타일링 변경
기타 사소한 버그 수정
더미데이터 일부 정리